### PR TITLE
Fix papertrail integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 before_install:
   - sudo apt-get install -qq graphviz
+before_script:
+  - gem list
 
 rvm:
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 before_install:
   - sudo apt-get install -qq graphviz
 before_script:
-  - gem --help
   - gem list
   - bundle show
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 before_install:
   - sudo apt-get install -qq graphviz
 before_script:
+  - gem --help
   - gem list
+  - bundle show
 
 rvm:
-  - 2.0.0
+  - 2.3.1
 gemfile:
   - gemfiles/Gemfile.rails-edge
 
@@ -19,5 +21,8 @@ matrix:
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-4.0
 
-    - rvm: 2.1.0
-      gemfile: gemfiles/Gemfile.rails-3.x
+    - rvm: 2.3.1
+      gemfile: gemfiles/Gemfile.rails-4.0
+
+    - rvm: 2.3.1
+      gemfile: gemfiles/Gemfile.rails-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ matrix:
 
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.rails-5.0
+  allow_failures:
+    - gemfile: gemfiles/Gemfile.rails-5.0
+    - gemfile: gemfiles/Gemfile.rails-edge
+

--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,22 @@ at http://rubygems.org/gems/workflow : select a version (optional,
 default is latest release), click "Documentation" link. When reading on
 github.com, the README refers to the upcoming release.
 
+**Note on ActiveRecord/Rails 5.0 Support:** currently the workflow gem only
+contains ActiveRecord integration for versions < 5.0. For now you can use
+[your own state persistence](https://github.com/geekq/workflow#custom-workflow-state-persistence)
+
+Since integration with ActiveRecord makes over 90% of the issues and
+maintenance effort, for including Rails/ActiveRecord 5.0 Support I am
+considering:
+
+* either to split ActiveRecord-Integration to as separate module/gem and allow
+  for independent release life cycle / maintainer
+* or separate only support for ActiveRecord 5.0
+* or use separate branch + version of workflow
+
+More background on
+[Rails integration](http://solnic.eu/2016/05/22/my-time-with-rails-is-up.html#not-a-good-citizen)
+
 What is workflow?
 -----------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -218,6 +218,8 @@ and include the workflow mixin in your model class as usual:
     class Order < ActiveRecord::Base
       include Workflow
       workflow do
+        with_callbacks # optionally invoke update callbacks with state
+transition
         # list states and transitions here
       end
     end

--- a/gemfiles/Gemfile.rails-4.0
+++ b/gemfiles/Gemfile.rails-4.0
@@ -9,5 +9,6 @@ group :development do
   gem "sqlite3"
   gem "mocha"
   gem "rake"
+  gem "test-unit"
   gem "ruby-graphviz", "~> 1.0.0"
 end

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -9,5 +9,6 @@ group :development do
   gem "sqlite3"
   gem "mocha"
   gem "rake"
+  gem "test-unit"
   gem "ruby-graphviz", "~> 1.0.0"
 end

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -1,11 +1,10 @@
 source "http://rubygems.org"
 
 group :development do
-  gem "minitest", "< 5.0.0" # 5.0.0 introduced incompatible changes renaming all the classes
   gem "rdoc", ">= 3.12"
   gem "bundler", ">= 1.0.0"
   gem "activerecord", "~>5.0"
-  gem 'protected_attributes'
+  # gem 'protected_attributes' only supported until Rails 5.0
   gem "sqlite3"
   gem "mocha"
   gem "rake"

--- a/gemfiles/Gemfile.rails-5.0
+++ b/gemfiles/Gemfile.rails-5.0
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+
+group :development do
+  gem "minitest", "< 5.0.0" # 5.0.0 introduced incompatible changes renaming all the classes
+  gem "rdoc", ">= 3.12"
+  gem "bundler", ">= 1.0.0"
+  gem "activerecord", "~>5.0"
+  gem 'protected_attributes'
+  gem "sqlite3"
+  gem "mocha"
+  gem "rake"
+  gem "ruby-graphviz", "~> 1.0.0"
+end

--- a/gemfiles/Gemfile.rails-edge
+++ b/gemfiles/Gemfile.rails-edge
@@ -1,13 +1,13 @@
 source "http://rubygems.org"
 
 group :development do
-  gem "minitest", "< 5.0.0" # 5.0.0 introduced incompatible changes renaming all the classes
   gem "rdoc", ">= 3.12"
   gem "bundler", ">= 1.0.0"
   gem "activerecord"
   gem "sqlite3"
   gem "mocha"
   gem "rake"
+  gem "test-unit"
   gem "ruby-graphviz", "~> 1.0.0"
   gem 'protected_attributes'
 end

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -16,7 +16,10 @@ module Workflow
         # database.
         def persist_workflow_state(new_value)
           # Rails 3.1 or newer
-          update_column self.class.workflow_column, new_value
+          run_callbacks :update do
+            self[self.class.workflow_column] = new_value
+            update_column self.class.workflow_column, new_value
+          end
         end
 
         private

--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -16,8 +16,12 @@ module Workflow
         # database.
         def persist_workflow_state(new_value)
           # Rails 3.1 or newer
-          run_callbacks :update do
-            self[self.class.workflow_column] = new_value
+          if self.class.workflow_spec && self.class.workflow_spec.with_callbacks
+            run_callbacks :update do
+              self[self.class.workflow_column] = new_value
+              update_column self.class.workflow_column, new_value
+            end
+          else
             update_column self.class.workflow_column, new_value
           end
         end

--- a/lib/workflow/specification.rb
+++ b/lib/workflow/specification.rb
@@ -5,13 +5,17 @@ require 'workflow/errors'
 
 module Workflow
   class Specification
-    attr_accessor :states, :initial_state, :meta,
+    attr_accessor :states, :initial_state, :meta, :with_callbacks,
       :on_transition_proc, :before_transition_proc, :after_transition_proc, :on_error_proc
 
     def initialize(meta = {}, &specification)
       @states = Hash.new
       @meta = meta
       instance_eval(&specification)
+    end
+
+    def with_callbacks
+      @with_callbacks = true
     end
 
     def state_names

--- a/test/attr_protected_test.rb
+++ b/test/attr_protected_test.rb
@@ -7,7 +7,11 @@ require 'sqlite3'
 require 'workflow'
 require 'mocha/setup'
 require 'stringio'
+
 require 'protected_attributes' if ActiveRecord::VERSION::MAJOR == 4
+
+# protected_attributes only supported until Rails 5.0
+if ActiveRecord::VERSION::MAJOR <= 4
 
 ActiveRecord::Migration.verbose = false
 
@@ -105,3 +109,4 @@ class AttrProtectedTest < ActiveRecordTestCase
 
 end
 
+end

--- a/test/attr_protected_test.rb
+++ b/test/attr_protected_test.rb
@@ -7,7 +7,7 @@ require 'sqlite3'
 require 'workflow'
 require 'mocha/setup'
 require 'stringio'
-require 'protected_attributes' if ActiveRecord::VERSION::MAJOR >= 4
+require 'protected_attributes' if ActiveRecord::VERSION::MAJOR == 4
 
 ActiveRecord::Migration.verbose = false
 

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -13,6 +13,8 @@ ActiveRecord::Migration.verbose = false
 class Order < ActiveRecord::Base
   include Workflow
   workflow do
+    with_callbacks
+
     state :submitted do
       event :accept, :transitions_to => :accepted, :meta => {:weight => 8} do |reviewer, args|
       end
@@ -104,6 +106,12 @@ class MainTest < ActiveRecordTestCase
     o = assert_state 'some order', 'accepted'
     assert o.ship!
     assert(o.instance_variable_get(:@capture_wf_change))
+  end
+
+  test 'after update hook is not called' do
+    o = assert_state 'some order', 'accepted', LegacyOrder
+    assert o.ship!
+    assert(!o.instance_variable_get(:@capture_wf_change))
   end
 
   test 'immediately save the new workflow_state on state machine transition' do

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -60,6 +60,8 @@ end
 class SpecialSmallImage < SmallImage
 end
 
+Order.after_update { @capture_wf_change = workflow_state_changed? }
+
 class MainTest < ActiveRecordTestCase
 
   def setup
@@ -96,6 +98,12 @@ class MainTest < ActiveRecordTestCase
     o = klass.find_by_title(title)
     assert_equal expected_state, o.read_attribute(klass.workflow_column)
     o
+  end
+
+  test 'after update hook is called' do
+    o = assert_state 'some order', 'accepted'
+    assert o.ship!
+    assert(o.instance_variable_get(:@capture_wf_change))
   end
 
   test 'immediately save the new workflow_state on state machine transition' do

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mocha'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']
   
   gem.required_ruby_version = '>= 1.9.2'

--- a/workflow.gemspec
+++ b/workflow.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'mocha'
+  gem.add_development_dependency 'protected_attributes'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'ruby-graphviz', ['~> 1.0.0']


### PR DESCRIPTION
- Add option to call `after_update` hooks when transitioning state.
- Papertrail uses the after upate hook of a model, this ensures that the
    update hooks are called when changing state.
- uses:

```
workflow do
  with_callbacks
    # other important directives
  end
```

when `with_callbacks` is used in the workflow specification,
ActiveRecord update callbacks will be invoked when transitioning state