### PR TITLE
Rails 5 paper trail and workflow compatibility

### DIFF
--- a/lib/workflow/adapters/active_record.rb
+++ b/lib/workflow/adapters/active_record.rb
@@ -15,9 +15,13 @@ module Workflow
         # On transition the new workflow state is immediately saved in the
         # database.
         def persist_workflow_state(new_value)
-          # Rails 3.1 or newer
+          # set dirty state of the column
           self[self.class.workflow_column] = new_value
-          update_column self.class.workflow_column, new_value
+          # in rails 5 update_column removes the dirty state on the instance
+          # using the class method maintains the dirty state
+          self.class
+            .where(self.class.primary_key => self[self.class.primary_key])
+            .update_all(self.class.workflow_column => new_value)
         end
 
         private


### PR DESCRIPTION
- in rails 5, instance.update_column removes the dirty state of the
instance, and therefore when papertrail looks for changes, it finds none
and no version is recorded.
- we avoid this by using the update_all method scoped by the primary key